### PR TITLE
fix: Same compiler options for all sub-projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,37 @@
 BUILD_DIR    := build
 INSTALL_DIR  := install
 LOG_DIR      := log
+CXX_FLAGS    := -Wall -Wextra -Wpedantic -Wunused-parameter -std=c++23
 
 all: interfaces common lane-detection manual-control obstacle-avoidance path-planning motion-calibration main-pipeline arduino-code
 
 arduino-code:
 	mkdir -p $(BUILD_DIR)
-	cd ./$(BUILD_DIR) && cmake ../arduino/ && make
+	cd ./$(BUILD_DIR) && cmake -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)" ../arduino/ && make
 
 interfaces:
 	colcon build --packages-select interfaces
 
 common:
-	colcon build --packages-select common
+	colcon build --packages-select common --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
 
 main-pipeline:
-	colcon build --packages-select main-pipeline
+	colcon build --packages-select main-pipeline --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
 
 lane-detection:
-	colcon build --packages-select lane-detection
+	colcon build --packages-select lane-detection --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
 
 manual-control:
-	colcon build --packages-select manual-control
+	colcon build --packages-select manual-control --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
 
 obstacle-avoidance:
-	colcon build --packages-select obstacle-avoidance
+	colcon build --packages-select obstacle-avoidance --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
 
 path-planning:
-	colcon build --packages-select path-planning
+	colcon build --packages-select path-planning --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
 
 motion-calibration:
-	colcon build --packages-select motion-calibration
+	colcon build --packages-select motion-calibration --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
 
 tests:
 	colcon test --packages-select interfaces --event-handlers console_direct+

--- a/arduino/CMakeLists.txt
+++ b/arduino/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
 project(arduino-code)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -std=c++23)
-endif()
-
 add_subdirectory(main)
 add_subdirectory(tests)

--- a/ros2-modules/common/CMakeLists.txt
+++ b/ros2-modules/common/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(common)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -std=c++20)
-endif()
-
 # let the compiler search for headers in the include folder
 include_directories(include)
 

--- a/ros2-modules/interfaces/CMakeLists.txt
+++ b/ros2-modules/interfaces/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(interfaces)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 # Find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)

--- a/ros2-modules/lane-detection/CMakeLists.txt
+++ b/ros2-modules/lane-detection/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(lane-detection)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -std=c++23)
-endif()
-
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/ros2-modules/manual-control/CMakeLists.txt
+++ b/ros2-modules/manual-control/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(manual-control)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -std=c++23)
-endif()
-
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/ros2-modules/motion-calibration/CMakeLists.txt
+++ b/ros2-modules/motion-calibration/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(motion-calibration)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -std=c++20)
-endif()
-
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/ros2-modules/obstacle-avoidance/CMakeLists.txt
+++ b/ros2-modules/obstacle-avoidance/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(obstacle-avoidance)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -std=c++20)
-endif()
-
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/ros2-modules/path-planning/CMakeLists.txt
+++ b/ros2-modules/path-planning/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(path-planning)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -std=c++20)
-endif()
-
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)


### PR DESCRIPTION
In order to use same compile options for each sub-project. I decided to use DCMAKE_CXX_FLAGS workaround. It is not the best solution but for gcc clang compilers it is okay