### PR TITLE
fix: change makefile compile flag passing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,42 @@
-BUILD_DIR    := build
-INSTALL_DIR  := install
-LOG_DIR      := log
-CXX_FLAGS    := -Wall -Wextra -Wpedantic -Wunused-parameter -std=c++23
+BUILD_DIR                 := build
+INSTALL_DIR               := install
+LOG_DIR                   := log
+# Allows to manually set or disable unit tests
+ENABLE_TESTS              := True
+# Allows to manually set or disable compiler warings VALID FOR GCC OR CLANG
+ADVANCED_COMPILER_OPTIONS := True
+# Allows to manually set or disable c++23 standard features
+LATEST_CPP_STANDARD       := True
 
 all: interfaces common lane-detection manual-control obstacle-avoidance path-planning motion-calibration main-pipeline arduino-code
 
 arduino-code:
 	mkdir -p $(BUILD_DIR)
-	cd ./$(BUILD_DIR) && cmake -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)" ../arduino/ && make
+	cd ./$(BUILD_DIR) && cmake -DBUILD_TESTING=$(ENABLE_TESTS) -DADVANCED_COMPILER_OPTIONS=$(ADVANCED_COMPILER_OPTIONS) -DLATEST_CPP_STANDARD=$(LATEST_CPP_STANDARD) ../arduino/ && make
 
 interfaces:
-	colcon build --packages-select interfaces
+	colcon build --packages-select interfaces --cmake-args -DBUILD_TESTING=$(ENABLE_TESTS) -DADVANCED_COMPILER_OPTIONS=$(ADVANCED_COMPILER_OPTIONS) -DLATEST_CPP_STANDARD=$(LATEST_CPP_STANDARD)
 
 common:
-	colcon build --packages-select common --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
+	colcon build --packages-select common --cmake-args -DBUILD_TESTING=$(ENABLE_TESTS) -DADVANCED_COMPILER_OPTIONS=$(ADVANCED_COMPILER_OPTIONS) -DLATEST_CPP_STANDARD=$(LATEST_CPP_STANDARD)
 
 main-pipeline:
-	colcon build --packages-select main-pipeline --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
+	colcon build --packages-select main-pipeline --cmake-args -DBUILD_TESTING=$(ENABLE_TESTS) -DADVANCED_COMPILER_OPTIONS=$(ADVANCED_COMPILER_OPTIONS) -DLATEST_CPP_STANDARD=$(LATEST_CPP_STANDARD)
 
 lane-detection:
-	colcon build --packages-select lane-detection --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
+	colcon build --packages-select lane-detection --cmake-args -DBUILD_TESTING=$(ENABLE_TESTS) -DADVANCED_COMPILER_OPTIONS=$(ADVANCED_COMPILER_OPTIONS) -DLATEST_CPP_STANDARD=$(LATEST_CPP_STANDARD)
 
 manual-control:
-	colcon build --packages-select manual-control --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
+	colcon build --packages-select manual-control --cmake-args -DBUILD_TESTING=$(ENABLE_TESTS) -DADVANCED_COMPILER_OPTIONS=$(ADVANCED_COMPILER_OPTIONS) -DLATEST_CPP_STANDARD=$(LATEST_CPP_STANDARD)
 
 obstacle-avoidance:
-	colcon build --packages-select obstacle-avoidance --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
+	colcon build --packages-select obstacle-avoidance --cmake-args -DBUILD_TESTING=$(ENABLE_TESTS) -DADVANCED_COMPILER_OPTIONS=$(ADVANCED_COMPILER_OPTIONS) -DLATEST_CPP_STANDARD=$(LATEST_CPP_STANDARD)
 
 path-planning:
-	colcon build --packages-select path-planning --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
+	colcon build --packages-select path-planning --cmake-args -DBUILD_TESTING=$(ENABLE_TESTS) -DADVANCED_COMPILER_OPTIONS=$(ADVANCED_COMPILER_OPTIONS) -DLATEST_CPP_STANDARD=$(LATEST_CPP_STANDARD)
 
 motion-calibration:
-	colcon build --packages-select motion-calibration --cmake-args -DCMAKE_CXX_FLAGS="$(CXX_FLAGS)"
+	colcon build --packages-select motion-calibration --cmake-args -DBUILD_TESTING=$(ENABLE_TESTS) -DADVANCED_COMPILER_OPTIONS=$(ADVANCED_COMPILER_OPTIONS) -DLATEST_CPP_STANDARD=$(LATEST_CPP_STANDARD)
 
 tests:
 	colcon test --packages-select interfaces --event-handlers console_direct+

--- a/arduino/CMakeLists.txt
+++ b/arduino/CMakeLists.txt
@@ -1,5 +1,17 @@
 cmake_minimum_required(VERSION 3.8)
 project(arduino-code)
 
+message(STATUS "Enable tests - " ${BUILD_TESTING})
+message(STATUS "Advanced complier options - " ${ADVANCED_COMPILER_OPTIONS})
+message(STATUS "Latest cpp standard - " ${LATEST_CPP_STANDARD})
+
+if (ADVANCED_COMPILER_OPTIONS)
+    add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough)
+endif()
+
+if (LATEST_CPP_STANDARD)
+    set(CMAKE_CXX_STANDARD 23)
+endif()
+
 add_subdirectory(main)
 add_subdirectory(tests)

--- a/arduino/tests/CMakeLists.txt
+++ b/arduino/tests/CMakeLists.txt
@@ -1,17 +1,19 @@
 cmake_minimum_required(VERSION 3.8)
 
-enable_testing()
+if(BUILD_TESTING)
+    enable_testing()
 
-find_package(GTest REQUIRED)
+    find_package(GTest REQUIRED)
 
-add_executable(motor_commands_tests
-               motor_commands_tests.cpp
-)
+    add_executable(motor_commands_tests
+                   motor_commands_tests.cpp
+    )
 
-target_link_libraries(motor_commands_tests
-                      motor-commands-lib
-                      GTest::gtest_main
-)
+    target_link_libraries(motor_commands_tests
+                          motor-commands-lib
+                          GTest::gtest_main
+    )
 
-include(GoogleTest)
-gtest_discover_tests(motor_commands_tests)
+    include(GoogleTest)
+    gtest_discover_tests(motor_commands_tests)
+endif()

--- a/ros2-modules/common/CMakeLists.txt
+++ b/ros2-modules/common/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.8)
 project(common)
 
+message(STATUS "Enable tests - " ${BUILD_TESTING})
+message(STATUS "Advanced complier options - " ${ADVANCED_COMPILER_OPTIONS})
+message(STATUS "Latest cpp standard - " ${LATEST_CPP_STANDARD})
+
+if (ADVANCED_COMPILER_OPTIONS)
+    add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough)
+endif()
+
+if (LATEST_CPP_STANDARD)
+    set(CMAKE_CXX_STANDARD 23)
+endif()
+
 # let the compiler search for headers in the include folder
 include_directories(include)
 
@@ -15,6 +27,7 @@ ament_target_dependencies(common rclcpp interfaces)
 ament_export_targets(common HAS_LIBRARY_TARGET)
 
 if(BUILD_TESTING)
+  enable_testing()
   #find_package(ament_lint_auto REQUIRED)
   #set(ament_cmake_copyright_FOUND TRUE)
   #set(ament_cmake_cpplint_FOUND TRUE)

--- a/ros2-modules/interfaces/CMakeLists.txt
+++ b/ros2-modules/interfaces/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.8)
 project(interfaces)
 
+message(STATUS "Enable tests - " ${BUILD_TESTING})
+message(STATUS "Advanced complier options - " ${ADVANCED_COMPILER_OPTIONS})
+message(STATUS "Latest cpp standard - " ${LATEST_CPP_STANDARD})
+
+if (ADVANCED_COMPILER_OPTIONS)
+    add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough)
+endif()
+
+if (LATEST_CPP_STANDARD)
+    set(CMAKE_CXX_STANDARD 23)
+endif()
+
 # Find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
@@ -10,6 +22,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
+  enable_testing()
   #find_package(ament_lint_auto REQUIRED)
   #set(ament_cmake_copyright_FOUND TRUE)
   #set(ament_cmake_cpplint_FOUND TRUE)

--- a/ros2-modules/lane-detection/CMakeLists.txt
+++ b/ros2-modules/lane-detection/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.8)
 project(lane-detection)
 
+message(STATUS "Enable tests - " ${BUILD_TESTING})
+message(STATUS "Advanced complier options - " ${ADVANCED_COMPILER_OPTIONS})
+message(STATUS "Latest cpp standard - " ${LATEST_CPP_STANDARD})
+
+if (ADVANCED_COMPILER_OPTIONS)
+    add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough)
+endif()
+
+if (LATEST_CPP_STANDARD)
+    set(CMAKE_CXX_STANDARD 23)
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -39,9 +51,8 @@ install(TARGETS
         lib/${PROJECT_NAME}
 )
 
-enable_testing()
-
 if(BUILD_TESTING)
+  enable_testing()
   #find_package(ament_lint_auto REQUIRED)
   #set(ament_cmake_copyright_FOUND TRUE)
   #set(ament_cmake_cpplint_FOUND TRUE)

--- a/ros2-modules/main-pipeline/CMakeLists.txt
+++ b/ros2-modules/main-pipeline/CMakeLists.txt
@@ -1,8 +1,16 @@
 cmake_minimum_required(VERSION 3.8)
 project(main-pipeline)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -std=c++20)
+message(STATUS "Enable tests - " ${BUILD_TESTING})
+message(STATUS "Advanced complier options - " ${ADVANCED_COMPILER_OPTIONS})
+message(STATUS "Latest cpp standard - " ${LATEST_CPP_STANDARD})
+
+if (ADVANCED_COMPILER_OPTIONS)
+    add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough)
+endif()
+
+if (LATEST_CPP_STANDARD)
+    set(CMAKE_CXX_STANDARD 23)
 endif()
 
 # find dependencies
@@ -39,6 +47,7 @@ install(TARGETS
 )
 
 if(BUILD_TESTING)
+  enable_testing()
   #find_package(ament_lint_auto REQUIRED)
   #set(ament_cmake_copyright_FOUND TRUE)
   #set(ament_cmake_cpplint_FOUND TRUE)

--- a/ros2-modules/manual-control/CMakeLists.txt
+++ b/ros2-modules/manual-control/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.8)
 project(manual-control)
 
+message(STATUS "Enable tests - " ${BUILD_TESTING})
+message(STATUS "Advanced complier options - " ${ADVANCED_COMPILER_OPTIONS})
+message(STATUS "Latest cpp standard - " ${LATEST_CPP_STANDARD})
+
+if (ADVANCED_COMPILER_OPTIONS)
+    add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough)
+endif()
+
+if (LATEST_CPP_STANDARD)
+    set(CMAKE_CXX_STANDARD 23)
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -31,9 +43,8 @@ install(TARGETS
         lib/${PROJECT_NAME}
 )
 
-enable_testing()
-
 if(BUILD_TESTING)
+  enable_testing()
   #find_package(ament_lint_auto REQUIRED)
   #set(ament_cmake_copyright_FOUND TRUE)
   #set(ament_cmake_cpplint_FOUND TRUE)

--- a/ros2-modules/motion-calibration/CMakeLists.txt
+++ b/ros2-modules/motion-calibration/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.8)
 project(motion-calibration)
 
+message(STATUS "Enable tests - " ${BUILD_TESTING})
+message(STATUS "Advanced complier options - " ${ADVANCED_COMPILER_OPTIONS})
+message(STATUS "Latest cpp standard - " ${LATEST_CPP_STANDARD})
+
+if (ADVANCED_COMPILER_OPTIONS)
+    add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough)
+endif()
+
+if (LATEST_CPP_STANDARD)
+    set(CMAKE_CXX_STANDARD 23)
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -32,9 +44,8 @@ install(TARGETS
         lib/${PROJECT_NAME}
 )
 
-enable_testing()
-
 if(BUILD_TESTING)
+  enable_testing()
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(digital_values_tests tests/digital_values_tests.cpp
                                        src/digital_values.cpp)

--- a/ros2-modules/obstacle-avoidance/CMakeLists.txt
+++ b/ros2-modules/obstacle-avoidance/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.8)
 project(obstacle-avoidance)
 
+message(STATUS "Enable tests - " ${BUILD_TESTING})
+message(STATUS "Advanced complier options - " ${ADVANCED_COMPILER_OPTIONS})
+message(STATUS "Latest cpp standard - " ${LATEST_CPP_STANDARD})
+
+if (ADVANCED_COMPILER_OPTIONS)
+    add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough)
+endif()
+
+if (LATEST_CPP_STANDARD)
+    set(CMAKE_CXX_STANDARD 23)
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -29,6 +41,7 @@ install(TARGETS
 )
 
 if(BUILD_TESTING)
+  enable_testing()
   #find_package(ament_lint_auto REQUIRED)
   #set(ament_cmake_copyright_FOUND TRUE)
   #set(ament_cmake_cpplint_FOUND TRUE)

--- a/ros2-modules/path-planning/CMakeLists.txt
+++ b/ros2-modules/path-planning/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.8)
 project(path-planning)
 
+message(STATUS "Enable tests - " ${BUILD_TESTING})
+message(STATUS "Advanced complier options - " ${ADVANCED_COMPILER_OPTIONS})
+message(STATUS "Latest cpp standard - " ${LATEST_CPP_STANDARD})
+
+if (ADVANCED_COMPILER_OPTIONS)
+    add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wuseless-cast -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough)
+endif()
+
+if (LATEST_CPP_STANDARD)
+    set(CMAKE_CXX_STANDARD 23)
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -29,6 +41,7 @@ install(TARGETS
 )
 
 if(BUILD_TESTING)
+  enable_testing()
   #find_package(ament_lint_auto REQUIRED)
   #set(ament_cmake_copyright_FOUND TRUE)
   #set(ament_cmake_cpplint_FOUND TRUE)


### PR DESCRIPTION
Rethink approach how to pass compile/build flags:
- decided to pass specific flags to each sub-project
- it is a little bit a boilerplate approach
- but if work with each build sub-project as separate one it is okay
- anyway compiler options must of the time will stay the same

The main limitation is` colcon build` command it does not work with "main" `CMakefile`